### PR TITLE
chore: revisions to accomodate increased provider versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ mock-user-data.log
 # Ignore Terraform lock files, as we want to test the Terraform code in these repos with the latest provider
 # versions.
 .terraform.lock.hcl
+
+# Ignore VSCode personalization config
+.vscode/settings.json

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,18 @@ terraform {
   # This module is now only being tested with Terraform 1.0.x. However, to make upgrading easier, we are setting
   # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
   # forwards compatible with 1.0.x code.
-  required_version = ">= 0.12.26"
+  required_version = ">= 1.4"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.73"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 4.73"
+    }
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Addresses [this notion issue](https://www.notion.so/buttoninc/Update-k8s-terraform-to-v4-67-0-or-later-2d0771acb02e4310813745d329b86f14?pvs=4). This PR updates terraform providers to their latest version. This allows us to make use of some newer features within our definitions of our infrastructure.  

## Changes

- Updates required providers within the module. 

## Notes

Marked this with tag `v0.10.0-b` as we have not done a thorough scan of any new or changed features to the providers versus the functionality of the module. The primary focus of the PR covers getting it running without errors. 